### PR TITLE
Rewrite and update Uncaught Mice Display

### DIFF
--- a/MH - Uncaught Mice Display.js
+++ b/MH - Uncaught Mice Display.js
@@ -75,6 +75,10 @@
 	 * @return {Promise} The response.
 	 */
 	const doRequest = async (url, formData) => {
+		if (typeof lastReadJournalEntryId === 'undefined' || typeof user === 'undefined') {
+			return;
+		}
+
 		if (! (lastReadJournalEntryId && user && user.unique_hash)) { // eslint-disable-line no-undef
 			return;
 		}

--- a/MH - Uncaught Mice Display.js
+++ b/MH - Uncaught Mice Display.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MH - Uncaught Mice Display
-// @version      1.0.4
+// @version      1.1.0
 // @description  Shows uncaught mice at any location
 // @author       MI
 // @match        https://www.mousehuntgame.com/*

--- a/MH - Uncaught Mice Display.js
+++ b/MH - Uncaught Mice Display.js
@@ -168,8 +168,8 @@
 				popup.addToken('{*title*}', `Mice in ${ user.environment_name }`);
 				popup.addToken('{*content*}', renderMiceList(mice));
 				popup.show();
-				}
 			}
+		}
 
 		if (0 === uncaughtCount) {
 			caughtBox.classList.add('mi-caught-all');
@@ -192,7 +192,6 @@
 				'page_arguments[sub_tab]' : 'location',
 			}
 		).then((data) => {
-			console.log(data)
 			// Behold! The Waterfall of Validation!
 			if (! (
 				data &&

--- a/MH - Uncaught Mice Display.js
+++ b/MH - Uncaught Mice Display.js
@@ -38,7 +38,7 @@
 	 * @param {string}   url         The url to match. If not provided, all ajax requests will be matched.
 	 * @param {boolean}  skipSuccess Skip the success check.
 	 */
-	 const onAjaxRequest = (callback, url = null, skipSuccess = false) => {
+	const onAjaxRequest = (callback, url = null, skipSuccess = false) => {
 		const req = XMLHttpRequest.prototype.open;
 		XMLHttpRequest.prototype.open = function () {
 			this.addEventListener('load', function () {
@@ -110,7 +110,7 @@
 
 	const renderMiceList = (mice) => {
 		let markup = '<div class="mh-uncaught-mice-list"><ul>';
-		mice.forEach(element => {
+		mice.forEach((element) => {
 			const mhctLink = `https://mhct.win/attractions.php?mouse_name=${ encodeURIComponent(element.name) }`;
 			markup += `<li class="mh-uncaught-mice ${ element.is_caught ? 'mh-uncaught-mice-caught' : 'mh-uncaught-mice-uncaught' }">
 				<img src="${ element.image }" alt="${ element.name }" title="${ element.name }" />
@@ -123,32 +123,32 @@
 		markup += '</ul></div>';
 
 		return markup;
-	}
+	};
 
 	/**
 	 * Create or update the uncaught mice display.
 	 *
-	 * @param {integer} uncaughtCount The number of uncaught mice.
+	 * @param {Array} locations The locations.
 	 */
 	const createOrUpdateDisplay = (locations) => {
 		const locationWrapper = document.querySelector('.mousehuntHud-environmentIconWrapper');
-		if (! locationWrapper ) {
+		if (! locationWrapper) {
 			return;
 		}
 
-		if (! (locations && user && user.environment_type && user.environment_name)) {
+		if (! (locations && user && user.environment_type && user.environment_name)) { // eslint-disable-line no-undef
 			return false;
 		}
 
 		const locationStats = locations.findIndex((location) => {
-			return location.type === user.environment_type;
+			return location.type === user.environment_type; // eslint-disable-line no-undef
 		});
 
-		if (locationStats === -1 || ! locations[locationStats] ) {
+		if (locationStats === -1 || ! locations[ locationStats ]) {
 			return false;
 		}
 
-		const uncaughtCount = locations[locationStats].total - locations[locationStats].caught;
+		const uncaughtCount = locations[ locationStats ].total - locations[ locationStats ].caught;
 
 		let caughtBox = document.querySelector('.mi-uncaught-box');
 		if (caughtBox) {
@@ -162,26 +162,26 @@
 		}
 
 		// merge all the arrays in the subgroup
-		if (locations[locationStats].subgroups) {
-			const mice = locations[locationStats].subgroups.reduce((acc, val) => acc.concat(val.mice), []);
+		if (locations[ locationStats ].subgroups) {
+			const mice = locations[ locationStats ].subgroups.reduce((acc, val) => acc.concat(val.mice), []);
 
 			caughtBox.onclick = () => {
-				var popup = new jsDialog();
+				const popup = new jsDialog(); // eslint-disable-line no-undef
 				popup.setIsModal(false);
 				popup.setTemplate('default');
-				popup.addToken('{*title*}', `Mice in ${ user.environment_name }`);
+				popup.addToken('{*title*}', `Mice in ${ user.environment_name }`); // eslint-disable-line no-undef
 				popup.addToken('{*content*}', renderMiceList(mice));
 				popup.show();
-			}
+			};
 		}
 
 		if (0 === uncaughtCount) {
 			caughtBox.classList.add('mi-caught-all');
-			catchBox.innerText = '🎉️';
+			caughtBox.innerText = '🎉️';
 		} else {
 			caughtBox.classList.remove('mi-caught-all');
 		}
-	}
+	};
 
 	/**
 	 * Render the uncaught mice.
@@ -191,9 +191,9 @@
 		doRequest(
 			'managers/ajax/pages/page.php',
 			{
-				'page_class': 'HunterProfile',
-				'page_arguments[tab]:': 'mice',
-				'page_arguments[sub_tab]' : 'location',
+				page_class: 'HunterProfile',
+				'page_arguments[tab]': 'mice',
+				'page_arguments[sub_tab]': 'location',
 			}
 		).then((data) => {
 			// Behold! The Waterfall of Validation!
@@ -204,16 +204,16 @@
 				data.page.tabs &&
 				data.page.tabs.mice &&
 				data.page.tabs.mice.subtabs &&
-				data.page.tabs.mice.subtabs[1] &&
-				data.page.tabs.mice.subtabs[1].mouse_list &&
-				data.page.tabs.mice.subtabs[1].mouse_list.categories
+				data.page.tabs.mice.subtabs[ 1 ] &&
+				data.page.tabs.mice.subtabs[ 1 ].mouse_list &&
+				data.page.tabs.mice.subtabs[ 1 ].mouse_list.categories
 			)) {
 				return;
 			}
 
-			createOrUpdateDisplay(data.page.tabs.mice.subtabs[1].mouse_list.categories);
+			createOrUpdateDisplay(data.page.tabs.mice.subtabs[ 1 ].mouse_list.categories);
 		});
-	}
+	};
 
 	addStyles(`.mi-uncaught-box {
 		position: absolute;

--- a/MH - Uncaught Mice Display.js
+++ b/MH - Uncaught Mice Display.js
@@ -10,107 +10,311 @@
 // @namespace https://greasyfork.org/users/748165
 // ==/UserScript==
 
-$(document).ready(function(){
-  if($(".campPage-trap-armedItemContainer")[0]){
-     typeof $(".mi-uncaught-box")[0] == "object"? null : uncaughtBoxRender()
-  }
-})
+((function () {
+	'use strict';
 
-//Renders the box
-function uncaughtBoxRender(){
-  var locationWrapper = $(".mousehuntHud-environmentIconWrapper")[0]
+	/**
+	 * Add styles to the page.
+	 *
+	 * @param {string} styles The styles to add.
+	 */
+	const addStyles = (styles) => {
+		const existingStyles = document.getElementById('maidenless-styles');
+		if (existingStyles) {
+			existingStyles.innerHTML += styles;
+			return;
+		}
 
-  //Box styles
-  var uncaughtBtn = document.createElement("button");
-  uncaughtBtn.className = "mi-uncaught-box";
-  uncaughtBtn.style.position = "absolute";
-  uncaughtBtn.style.width = "17px";
-  uncaughtBtn.style.height = "17px";
-  uncaughtBtn.style.borderRadius = "4px";
-  uncaughtBtn.style.left = "1px";
-  uncaughtBtn.style.bottom = "3px";
-  uncaughtBtn.style.background = "#e5dac0";
-  uncaughtBtn.style.borderColor = "#9f9171";
-  uncaughtBtn.style.fontSize = "10px"
-  uncaughtBtn.style.padding = "0px"
-  uncaughtBtn.style.innerHTML = "?"
+		const style = document.createElement('style');
+		style.id = 'maidenless-styles';
+		style.innerHTML = styles;
+		document.head.appendChild(style);
+	};
 
-  //Button function --- 
-  var currentLocation = user.environment_type;
-  //Firstly calls for the location informations
-  uncaughtBtn.onclick = function(){
-    console.log("Requesting Information of Location Mice from Server");
-    postReq("https://www.mousehuntgame.com/managers/ajax/pages/page.php",
-    `sn=Hitgrab&hg_is_ajax=1&page_class=HunterProfile&page_arguments%5Btab%5D=mice&page_arguments%5Bsub_tab%5D=location&last_read_journal_entry_id=${lastReadJournalEntryId}&uh=${user.unique_hash}`
-    ). then(res =>{
-      try{
-        var response = JSON.parse(res.responseText);
-        if (response){
-          var miceListCategory = {}
-          miceListCategory = response.page.tabs.mice.subtabs[1].mouse_list.categories;
-          //Loops through the parsed data to find the matching locationx  
-          for(var i=0; i< miceListCategory.length;i++){
-            if(miceListCategory[i].type == currentLocation){
-              console.log("Current location_type is " + miceListCategory[i].type);
-              var miceTotal = miceListCategory[i].total
-              var locationMiceList = miceListCategory[i].subgroups[0].mice
+	/**
+	 * Do something when ajax requests are completed.
+	 *
+	 * @param {Function} callback    The callback to call when an ajax request is completed.
+	 * @param {string}   url         The url to match. If not provided, all ajax requests will be matched.
+	 * @param {boolean}  skipSuccess Skip the success check.
+	 */
+	 const onAjaxRequest = (callback, url = null, skipSuccess = false) => {
+		const req = XMLHttpRequest.prototype.open;
+		XMLHttpRequest.prototype.open = function () {
+			this.addEventListener('load', function () {
+				if (this.responseText) {
+					let response = {};
+					try {
+						response = JSON.parse(this.responseText);
+					} catch (e) {
+						return;
+					}
 
-              //Mega lists which shows all the mice uncaught in that area
-              var uncaughtMiceList = [];
-              for (var i=0; i<miceTotal -1; i++){
-                if(locationMiceList[i].num_catches == 0){
-                  uncaughtMiceList.push(locationMiceList[i].name)
-                }
-              }
+					if (response.success || skipSuccess) {
+						if (! url) {
+							callback(response);
+							return;
+						}
 
-              //String it up
-              var str = "Uncaught Mice: "
-              for (var i=0; i< uncaughtMiceList.length; i++){
-                str = str + "\n" + uncaughtMiceList[i]
-              }
-              
-              //Different announcement if all mice caught
-              //Changes colour if all caught
-              if (uncaughtMiceList.length > 0){
-                alert (str)
-                uncaughtBtn.innerHTML = uncaughtMiceList.length;
-              } else {
-                uncaughtBtn.innerHTML = "0";
-                uncaughtBtn.style.background = "green";
-                uncaughtBtn.style.color = "white";
-                uncaughtBtn.style.borderColor = "green";
-                alert ("All mice in this location have been caught")
-              }
+						if (this.responseURL.indexOf(url) !== -1) {
+							callback(response);
+						}
+					}
+				}
+			});
+			req.apply(this, arguments);
+		};
+	};
 
-              break;
-            }
-          }
+	/**
+	 * POST a request to the server and return the response.
+	 *
+	 * @param {string} url  The url to post to, not including the base url.
+	 * @param {Object} data The data to post.
+	 *
+	 * @returns {Promise} The response.
+	 */
+	const doRequest = async (url, formData) => {
+		// Build the form for the request.
+		const form = new FormData();
+		form.append('sn', 'Hitgrab');
+		form.append('hg_is_ajax', 1);
+		form.append('last_read_journal_entry_id', lastReadJournalEntryId ? lastReadJournalEntryId : 0);
+		form.append('uh', user.unique_hash ? user.unique_hash : '');
 
-        }
-      } catch (error){
-        console.log(error)
-      }
-    })
-  },
-  
+		// Add in the form data.
+		for (const key in formData) {
+			form.append(key, formData[key]);
+		}
 
-  locationWrapper.insertAdjacentElement("afterend",uncaughtBtn)
+		const requestBody = new URLSearchParams(form).toString();
 
-}
+		const response = await fetch(
+			callbackurl ? callbackurl + url  : 'https://www.mousehuntgame.com/' + url,
+			{
+				method: 'POST',
+				body: requestBody,
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+			}
+		);
 
-function postReq(url, form) {
-  return new Promise((resolve, reject) => {
-    const xhr = new XMLHttpRequest();
-    xhr.open("POST", url, true);
-    xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-    xhr.onreadystatechange = function () {
-      if (this.readyState === XMLHttpRequest.DONE && this.status === 200) {
-        resolve(this);
-      }
-    };
-    xhr.onerror = function () {
-      reject(this);
-    };
-    xhr.send(form);
-  });
-}
+		const data = await response.json();
+		return data;
+	}
+
+	const renderMiceList = (mice) => {
+		let markup = '<div class="mh-uncaught-mice-list"><ul>';
+		mice.forEach(element => {
+			const mhctLink = `https://mhct.win/attractions.php?mouse_name=${ encodeURIComponent(element.name) }`;
+			markup += `<li class="mh-uncaught-mice ${ element.is_caught ? 'mh-uncaught-mice-caught' : 'mh-uncaught-mice-uncaught' }">
+				<img src="${ element.image }" alt="${ element.name }" title="${ element.name }" />
+				<div class="mh-uncaught-mice-caught-crown ${ element.crown }"></div>
+				<div class="mh-uncaught-mice-name name">
+					<a href="${ mhctLink }"  target="mhct_search" rel="noopener noreferrer">${ element.name }</a>
+				</div>
+			</li>`;
+		});
+		markup += '</ul></div>';
+
+		return markup;
+	}
+
+	/**
+	 * Create or update the uncaught mice display.
+	 *
+	 * @param {integer} uncaughtCount The number of uncaught mice.
+	 */
+	const createOrUpdateDisplay = (locations) => {
+		const locationWrapper = document.querySelector('.mousehuntHud-environmentIconWrapper');
+		if (! locationWrapper ) {
+			return;
+		}
+
+		if (! (locations && user && user.environment_type && user.environment_name)) {
+			return false;
+		}
+
+		const locationStats = locations.findIndex((location) => {
+			return location.type === user.environment_type;
+		});
+
+		if (locationStats === -1 || ! locations[locationStats] ) {
+			return false;
+		}
+
+		const uncaughtCount = locations[locationStats].total - locations[locationStats].caught;
+
+		let caughtBox = document.querySelector('.mi-uncaught-box');
+		if (caughtBox) {
+			caughtBox.innerText = uncaughtCount;
+			caughtBox.onclick = null;
+		} else {
+			caughtBox = document.createElement('div');
+			caughtBox.classList.add('mi-uncaught-box');
+			caughtBox.innerText = uncaughtCount;
+			locationWrapper.appendChild(caughtBox);
+		}
+
+		// merge all the arrays in the subgroup
+		if (locations[locationStats].subgroups) {
+			const mice = locations[locationStats].subgroups.reduce((acc, val) => acc.concat(val.mice), []);
+
+			caughtBox.onclick = () => {
+				var popup = new jsDialog();
+				popup.setIsModal(false);
+				popup.setTemplate('default');
+				popup.addToken('{*title*}', `Mice in ${ user.environment_name }`);
+				popup.addToken('{*content*}', renderMiceList(mice));
+				popup.show();
+				}
+			}
+
+		if (0 === uncaughtCount) {
+			caughtBox.classList.add('mi-caught-all');
+			catchBox.innerText = '🎉️';
+		} else {
+			caughtBox.classList.remove('mi-caught-all');
+		}
+	}
+
+	/**
+	 * Render the uncaught mice.
+	 */
+	const getDataAndRenderCount = () => {
+		// Grab all mice data.
+		doRequest(
+			'managers/ajax/pages/page.php',
+			{
+				'page_class': 'HunterProfile',
+				'page_arguments[tab]:': 'mice',
+				'page_arguments[sub_tab]' : 'location',
+			}
+		).then((data) => {
+			console.log(data)
+			// Behold! The Waterfall of Validation!
+			if (! (
+				data &&
+				data.success &&
+				data.page &&
+				data.page.tabs &&
+				data.page.tabs.mice &&
+				data.page.tabs.mice.subtabs &&
+				data.page.tabs.mice.subtabs[1] &&
+				data.page.tabs.mice.subtabs[1].mouse_list &&
+				data.page.tabs.mice.subtabs[1].mouse_list.categories
+			)) {
+				return;
+			}
+
+			createOrUpdateDisplay(data.page.tabs.mice.subtabs[1].mouse_list.categories);
+		});
+	}
+
+	addStyles(`.mi-uncaught-box {
+		position: absolute;
+		width: 20px;
+		height: 20px;
+		border-radius: 4px;
+		left: 2px;
+		bottom: 3px;
+		background-color: #d9cca3;
+		font-size: 11px;
+		padding: 0;
+		vertical-align: middle;
+		text-shadow: 0 0 1px #ae9b6d;
+		color: #462402;
+		text-align: center;
+		line-height: 20px;
+		font-weight: 700;
+		border-bottom-right-radius: 0;
+		border-top-left-radius: 0;
+		box-shadow: 2px 2px 2px #e5dac0 inset, -2px -2px 2px #9f9171 inset;
+	}
+
+	.mi-caught-all {
+		background-color: #fff7b3;
+	}
+
+	.mh-uncaught-mice-list ul {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-evenly;
+		align-items: stretch;
+	}
+
+	.mh-uncaught-mice {
+		width: 95px;
+		border: 1px solid #9b9b9b;
+		margin: 2px;
+		padding-top: 10px;
+		border-radius: 5px;
+		position: relative;
+		text-align: center;
+	}
+
+	.mh-uncaught-mice-uncaught {
+		background-color: #e0e0e0;
+	}
+
+	.mh-uncaught-mice-name.name {
+		padding: 5px;
+	}
+
+	.mh-uncaught-mice-caught-crown.bronze,
+	.mh-uncaught-mice-caught-crown.silver,
+	.mh-uncaught-mice-caught-crown.gold,
+	.mh-uncaught-mice-caught-crown.platinum,
+	.mh-uncaught-mice-caught-crown.diamond {
+		position: absolute;
+		top: 0;
+		right: 0;
+		height: 30px;
+		width: 30px;
+		background-color: #fff;
+		background-position: center center;
+		background-repeat: no-repeat;
+		background-size: 30px 30px;
+		border-bottom-left-radius: 5px;
+		border-bottom: 1px solid #b1b1b1;
+		border-left: 1px solid #b1b1b1;
+		border-top-right-radius: 8px;
+		box-shadow: -1px 1px 0 1px white;
+
+	}
+
+	.mh-uncaught-mice-caught-crown.bronze {
+		background-image: url('https://www.mousehuntgame.com/images/ui/crowns/crown_bronze.png');
+	}
+
+	.mh-uncaught-mice-caught-crown.silver {
+		background-image: url('https://www.mousehuntgame.com/images/ui/crowns/crown_silver.png');
+	}
+
+	.mh-uncaught-mice-caught-crown.gold {
+		background-image: url('https://www.mousehuntgame.com/images/ui/crowns/crown_gold.png');
+	}
+
+	.mh-uncaught-mice-caught-crown.platinum {
+		background-image: url('https://www.mousehuntgame.com/images/ui/crowns/crown_platinum.png');
+	}
+
+	.mh-uncaught-mice-caught-crown.diamond {
+		background-image: url('https://www.mousehuntgame.com/images/ui/crowns/crown_diamond.png');
+	}
+
+	.mh-uncaught-mice-caught-count {
+		display: inline-block;
+		vertical-align: top;
+		margin-top: 3px;
+	}
+	`);
+
+	// Fire off the initial render.
+	getDataAndRenderCount();
+
+	// On horn or traveling, update the count.
+	onAjaxRequest(getDataAndRenderCount, '/managers/ajax/turns/activeturn.php');
+	onAjaxRequest(getDataAndRenderCount, '/managers/ajax/users/changeenvironment.php'); // Kind of like the change page.
+})());

--- a/MH - Uncaught Mice Display.js
+++ b/MH - Uncaught Mice Display.js
@@ -69,28 +69,32 @@
 	/**
 	 * POST a request to the server and return the response.
 	 *
-	 * @param {string} url  The url to post to, not including the base url.
-	 * @param {Object} data The data to post.
+	 * @param {string} url      The url to post to, not including the base url.
+	 * @param {Object} formData The form data to post.
 	 *
-	 * @returns {Promise} The response.
+	 * @return {Promise} The response.
 	 */
 	const doRequest = async (url, formData) => {
+		if (! (lastReadJournalEntryId && user && user.unique_hash)) { // eslint-disable-line no-undef
+			return;
+		}
+
 		// Build the form for the request.
 		const form = new FormData();
 		form.append('sn', 'Hitgrab');
 		form.append('hg_is_ajax', 1);
-		form.append('last_read_journal_entry_id', lastReadJournalEntryId ? lastReadJournalEntryId : 0);
-		form.append('uh', user.unique_hash ? user.unique_hash : '');
+		form.append('last_read_journal_entry_id', lastReadJournalEntryId ? lastReadJournalEntryId : 0); // eslint-disable-line no-undef
+		form.append('uh', user.unique_hash ? user.unique_hash : ''); // eslint-disable-line no-undef
 
 		// Add in the form data.
 		for (const key in formData) {
-			form.append(key, formData[key]);
+			form.append(key, formData[ key ]);
 		}
 
 		const requestBody = new URLSearchParams(form).toString();
 
 		const response = await fetch(
-			callbackurl ? callbackurl + url  : 'https://www.mousehuntgame.com/' + url,
+			callbackurl ? callbackurl + url : 'https://www.mousehuntgame.com/' + url, // eslint-disable-line no-undef
 			{
 				method: 'POST',
 				body: requestBody,
@@ -102,7 +106,7 @@
 
 		const data = await response.json();
 		return data;
-	}
+	};
 
 	const renderMiceList = (mice) => {
 		let markup = '<div class="mh-uncaught-mice-list"><ul>';

--- a/MH - Uncaught Mice Display.js
+++ b/MH - Uncaught Mice Display.js
@@ -231,6 +231,7 @@
 		border-bottom-right-radius: 0;
 		border-top-left-radius: 0;
 		box-shadow: 2px 2px 2px #e5dac0 inset, -2px -2px 2px #9f9171 inset;
+		cursor: pointer;
 	}
 
 	.mi-caught-all {


### PR DESCRIPTION
Ended up rewriting the script as I was making some changes.

The current uncaught box looks like this:
![Screen Shot 2022-10-17 at 5 26 33 PM](https://user-images.githubusercontent.com/66798/196295302-d7cd2e10-0ce2-47b2-a408-3723fbbe82a0.png)

Clicking on the box gives you a popup with this:
![Screen Shot 2022-10-17 at 5 27 41 PM](https://user-images.githubusercontent.com/66798/196295439-96cd1b30-22f8-4015-9141-64fb19fceeb2.png)

Currently, the mouse names link to MHCT attractions for that mouse.
