### PR TITLE
Zokor minluck fix (eff, not MP)

### DIFF
--- a/MH_-_Minluck__CRE_tool_v2.0_new.user.js
+++ b/MH_-_Minluck__CRE_tool_v2.0_new.user.js
@@ -5550,13 +5550,8 @@ function specialMPEff(mouseName, mouse_power, eff) {
     // Credit to tsitu and Neb for calculating
     if (locationName == "Zokor") {
         var bossCheck = user.quests.QuestAncientCity.boss;
-        if (bossCheck == "defeated") {
-            if (mouseName == "Reanimated Carver") {
-                mouse_power *= 5 / 9;
-            }
-            else {
-                mouse_power *= 3 / 4;
-            }
+        if (bossCheck == "defeated" && powerType == "Forgotten") {
+                eff += 1;
         }
     }
 


### PR DESCRIPTION
Minlucks in Zokor were wrong, due to how we calculated after boss MP/E.
MP doesn't change, eff does.

Needs testing if works in live, then can also add version up.